### PR TITLE
Add views and tests for the new optgroup feature in deform

### DIFF
--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -1077,6 +1077,55 @@ class DeformDemo(object):
         form = deform.Form(schema, buttons=('submit',))
         return self.render_form(form)
 
+    @view_config(renderer='templates/form.pt', name='select_with_optgroup')
+    @demonstrate('Select Widget (with optgroup)')
+    def select_with_optgroup(self):
+        from deform.widget import OptGroup
+        choices = (
+               ('', 'Select your favorite musician'),
+               OptGroup('Guitarists',
+                        ('page', 'Jimmy Page'),
+                        ('hendrix', 'Jimi Hendrix')),
+               OptGroup('Drummers',
+                       ('cobham', 'Billy Cobham'),
+                       ('bonham', 'John Bonham')))
+        class Schema(colander.Schema):
+            musician = colander.SchemaNode(
+                colander.String(),
+                widget=deform.widget.SelectWidget(values=choices)
+                )
+        schema = Schema()
+        form = deform.Form(schema, buttons=('submit',))
+        return self.render_form(form)
+
+    @view_config(renderer='templates/form.pt',
+                 name='select_with_optgroup_and_label_attributes')
+    @demonstrate('Select Widget (with optgroup and label attributes)')
+    def select_with_optgroup_and_label_attributes(self):
+        # One may or may not notice any difference with
+        # 'select_with_optgroup' above, depending on the browser being
+        # used. See widget's documentation for further details.
+        from deform.widget import OptGroup
+        choices = (
+               ('', 'Select your favorite musician'),
+               OptGroup('Guitarists',
+                        ('page', 'Jimmy Page'),
+                        ('hendrix', 'Jimi Hendrix')),
+               OptGroup('Drummers',
+                       ('cobham', 'Billy Cobham'),
+                       ('bonham', 'John Bonham')))
+        long_label_gener = lambda group, label: ' - '.join((group, label))
+        class Schema(colander.Schema):
+            musician = colander.SchemaNode(
+                colander.String(),
+                widget=deform.widget.SelectWidget(
+                    values=choices,
+                    long_label_generator=long_label_gener)
+                )
+        schema = Schema()
+        form = deform.Form(schema, buttons=('submit',))
+        return self.render_form(form)
+
     @view_config(renderer='templates/form.pt', name='checkboxchoice')
     @demonstrate('Checkbox Choice Widget')
     def checkboxchoice(self):

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -1961,6 +1961,64 @@ class SelectWidgetIntegerTests(Base, unittest.TestCase):
             captured, 
             "{'number': 0}")
 
+class SelectWidgetWithOptgroupTest(Base, unittest.TestCase):
+    url = "/select_with_optgroup/"
+
+    def test_render_default(self):
+        browser.open(self.url)
+        browser.wait_for_page_to_load("30000")
+        self.assertTrue(browser.is_text_present('Musician'))
+        self.assertEqual(browser.get_attribute('deformField1@name'), 'musician')
+        self.assertEqual(browser.get_selected_index('deformField1'), '0')
+        options = browser.get_select_options('deformField1')
+        self.assertEqual(
+            options,
+            [u'Select your favorite musician',
+             u'Jimmy Page', u'Jimi Hendrix', u'Billy Cobham', u'John Bonham']) 
+        self.assertEqual(browser.get_text('css=.req'), '*')
+        self.assertEqual(browser.get_text('css=#captured'), 'None')
+        self.assertEqual(int(browser.get_xpath_count('//optgroup')), 2)
+
+    def test_submit_selected(self):
+        browser.open(self.url)
+        browser.wait_for_page_to_load("30000")
+        browser.select('deformField1', 'index=1')
+        browser.click('submit')
+        browser.wait_for_page_to_load("30000")
+        self.assertFalse(browser.is_element_present('css=.errorMsgLbl'))
+        self.assertEqual(browser.get_selected_index('deformField1'), '1')
+        captured = browser.get_text('css=#captured')
+        # With or without "u"...
+        expected = ("{'musician': 'page'}", "{'musician': u'page'}")
+        self.assertTrue(captured in expected)
+
+class SelectWidgetWithOptgroupAndLabelTest(SelectWidgetWithOptgroupTest):
+    url = "/select_with_optgroup_and_label_attributes/"
+
+    def test_render_default(self):
+        browser.open(self.url)
+        browser.wait_for_page_to_load("30000")
+        self.assertTrue(browser.is_text_present('Musician'))
+        self.assertEqual(browser.get_attribute('deformField1@name'), 'musician')
+        self.assertEqual(browser.get_selected_index('deformField1'), '0')
+        # We cannot test what the options look like because it depends
+        # on the browser.
+        self.assertEqual(browser.get_text('css=.req'), '*')
+        self.assertEqual(browser.get_text('css=#captured'), 'None')
+        self.assertEqual(int(browser.get_xpath_count('//optgroup')), 2)
+
+    def test_submit_selected(self):
+        browser.open(self.url)
+        browser.wait_for_page_to_load("30000")
+        browser.select('deformField1', 'index=1')
+        browser.click('submit')
+        browser.wait_for_page_to_load("30000")
+        self.assertFalse(browser.is_element_present('css=.errorMsgLbl'))
+        self.assertEqual(browser.get_selected_index('deformField1'), '1')
+        captured = browser.get_text('css=#captured')
+        expected = ("{'musician': 'page'}", "{'musician': u'page'}")
+        self.assertTrue(captured in expected)
+
 class TextInputWidgetTests(Base, unittest.TestCase):
     url = "/textinput/"
     def test_render_default(self):


### PR DESCRIPTION
Here are new views and tests for the proposed "optgroup" feature in deform (see Pylons/deform#87).
