### PR TITLE
Deform2: fix for pyramid 1.5a2

### DIFF
--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2274,6 +2274,7 @@ def main(global_config, **settings):
     renderer = settings['deformdemo.renderer']
     session_factory = UnencryptedCookieSessionFactoryConfig('seekrit!')
     config = Configurator(settings=settings, session_factory=session_factory)
+    config.include('pyramid_chameleon')
     renderer = config.maybe_dotted(renderer)
     deform.Form.set_default_renderer(renderer)
     config.add_static_view('static_deform', 'deform:static')

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ PY3 = sys.version_info[0] == 3
 
 requires = ['deform>=2.0dev',
             'pyramid>=1.5a1', # route_name argument to resource_url
+            'pyramid_chameleon',
             'pygments',
             'waitress']
 


### PR DESCRIPTION
Need `pyramid_chameleon` for `pyramid` >= 1.5a2

[edited: removed derogatory comments about form.css]
