### PR TITLE
python 2.6 needs absolute_import

### DIFF
--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 import unittest
 import re


### PR DESCRIPTION
Otherwise the import from `selenium.common.exceptions` in `deformdemo.test` fails due to ambiguity with `deformdemo.selenium`.
