### PR TITLE
Add buttons to select form layout

### DIFF
--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -73,8 +73,18 @@ class DeformDemo(object):
         self.request = request
         self.macros = get_renderer('templates/main.pt').implementation().macros
 
+        if 'bs_form_style' in self.request.GET:
+            session = self.request.session
+            bs_form_style = self.request.GET['bs_form_style']
+            if bs_form_style not in ('form-horizontal', 'form-inline'):
+                bs_form_style = None
+            session['bootstrap_form_style'] = bs_form_style
+
     def render_form(self, form, appstruct=colander.null, submitted='submit',
                     success=None, readonly=False, is_i18n=False):
+
+        session = self.request.session
+        form.bootstrap_form_style = session.get('bootstrap_form_style')
 
         captured = None
 
@@ -118,6 +128,7 @@ class DeformDemo(object):
             'end':end,
             'is_i18n':is_i18n,
             'locale': locale_name,
+            'bs_form_style': form.bootstrap_form_style,
             'demos':self.get_demos(),
             'title':self.get_title(),
             'css_links':reqts['css'],

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -73,18 +73,19 @@ class DeformDemo(object):
         self.request = request
         self.macros = get_renderer('templates/main.pt').implementation().macros
 
-        if 'bs_form_style' in self.request.GET:
+        if 'form_class' in self.request.GET:
             session = self.request.session
-            bs_form_style = self.request.GET['bs_form_style']
-            if bs_form_style not in ('form-horizontal', 'form-inline'):
-                bs_form_style = None
-            session['bootstrap_form_style'] = bs_form_style
+            form_class = self.request.GET['form_class']
+            if form_class not in ('form-horizontal', 'form-inline'):
+                form_class = None
+            session['form_class'] = form_class
 
     def render_form(self, form, appstruct=colander.null, submitted='submit',
                     success=None, readonly=False, is_i18n=False):
 
-        session = self.request.session
-        form.bootstrap_form_style = session.get('bootstrap_form_style')
+        form_class = self.request.session.get('form_class')
+        if form_class:
+            form.widget = deform.widget.FormWidget(css_class=form_class)
 
         captured = None
 
@@ -128,7 +129,7 @@ class DeformDemo(object):
             'end':end,
             'is_i18n':is_i18n,
             'locale': locale_name,
-            'bs_form_style': form.bootstrap_form_style,
+            'form_class': form.widget.css_class,
             'demos':self.get_demos(),
             'title':self.get_title(),
             'css_links':reqts['css'],

--- a/deformdemo/templates/main.pt
+++ b/deformdemo/templates/main.pt
@@ -45,14 +45,33 @@
 
     <body id="public">
 
-    <div class="navbar navbar-default" role="navigation">
-        <div class="container">
-            <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span> Deform 2 Demo</a>
+      <div class="container">
+        <div class="navbar navbar-default" role="navigation">
+          <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span> Deform 2 Demo</a>
+          <p class="navbar-text pull-right">
+          Form Layout
+            <span class="btn-group">
+              <a tal:define="active not bs_form_style"
+                 class="btn btn-default ${active and 'active' or ''}"
+                 href="${request.path_url}?bs_form_style=">
+                Default
+              </a>
+              <a tal:define="active bs_form_style == 'form-horizontal'"
+                 class="btn btn-default ${active and 'active' or ''}"
+                 href="${request.path_url}?bs_form_style=form-horizontal">
+                Horizontal
+              </a>
+              <a tal:define="active bs_form_style == 'form-inline'"
+                 class="btn btn-default ${active and 'active' or ''}"
+                 href="${request.path_url}?bs_form_style=form-inline">
+                Inline
+              </a>
+            </span>
+          </p>
         </div>
-    </div>
+      </div>
 
-    <div class="container">
-
+      <div class="container">
         <div class="row" style="margin-top: 10px">
             <div class="col-3 col-lg-3 col-sm-3">
                 <div class="list-group">

--- a/deformdemo/templates/main.pt
+++ b/deformdemo/templates/main.pt
@@ -48,9 +48,11 @@
       <div class="container">
         <div class="navbar navbar-default" role="navigation">
           <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span> Deform 2 Demo</a>
-          <p class="navbar-text pull-right">
+          <p class="navbar-text pull-right"
+             tal:condition="form|None">
           Form Layout
-            <span class="btn-group">
+            <span class="btn-group"
+                  tal:define="bs_form_style bs_form_style|None">
               <a tal:define="active not bs_form_style"
                  class="btn btn-default ${active and 'active' or ''}"
                  href="${request.path_url}?bs_form_style=">

--- a/deformdemo/templates/main.pt
+++ b/deformdemo/templates/main.pt
@@ -52,20 +52,20 @@
              tal:condition="form|None">
           Form Layout
             <span class="btn-group"
-                  tal:define="bs_form_style bs_form_style|None">
-              <a tal:define="active not bs_form_style"
+                  tal:define="form_class form_class|None">
+              <a tal:define="active not form_class"
                  class="btn btn-default ${active and 'active' or ''}"
-                 href="${request.path_url}?bs_form_style=">
+                 href="${request.path_url}?form_class=">
                 Default
               </a>
-              <a tal:define="active bs_form_style == 'form-horizontal'"
+              <a tal:define="active form_class == 'form-horizontal'"
                  class="btn btn-default ${active and 'active' or ''}"
-                 href="${request.path_url}?bs_form_style=form-horizontal">
+                 href="${request.path_url}?form_class=form-horizontal">
                 Horizontal
               </a>
-              <a tal:define="active bs_form_style == 'form-inline'"
+              <a tal:define="active form_class == 'form-inline'"
                  class="btn btn-default ${active and 'active' or ''}"
-                 href="${request.path_url}?bs_form_style=form-inline">
+                 href="${request.path_url}?form_class=form-inline">
                 Inline
               </a>
             </span>

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -2626,7 +2626,7 @@ class CssClassesOnTheOutermostHTMLElementTests(Base, unittest.TestCase):
     def test_it(self):
         findcss('form > fieldset > div.top_level_mapping_widget_custom_class')
         findcss('[title=MappingWidget] div.mapped_widget_custom_class')
-        findcss('[title=SequenceWidget] div.sequenced_widget_custom_class')
+        findcss('#item-deformField2 div.sequenced_widget_custom_class')
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds some navbar buttons to control the setting of `Form.widget.css_class`.

This is a companion to Pylons/deform#282.

(This is PR #25 rebased onto the current `master`.)