### PR TITLE
[WIP] Add examples of using `tags` options on `Select2Widget` 

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -111,3 +111,4 @@ Contributors
 - Érico Andrei 2018/11/10
 - Steve Piercy 2020/05/11
 - John Haiducek 2020/06/20
+- Maksym Shalenyi 2020/06/20

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2034,6 +2034,44 @@ class DeformDemo(object):
 
         return self.render_form(form)
 
+    @view_config(renderer="templates/form.pt", name="select2_with_tags")
+    @demonstrate("Select2 Widget (with tags)")
+    def select2_with_tags(self):
+
+        choices = ()
+
+        class Schema(colander.Schema):
+            pepper = colander.SchemaNode(
+                colander.String(),
+                widget=deform.widget.Select2Widget(values=choices, tags=True),
+            )
+
+        schema = Schema()
+        form = deform.Form(schema, buttons=("submit",))
+
+        return self.render_form(form)
+
+    @view_config(
+        renderer="templates/form.pt", name="select2_with_tags_and_multiple"
+    )
+    @demonstrate("Select2 Widget (with tags and multiple)")
+    def select2_with_tags_and_multiple(self):
+
+        choices = ()
+
+        class Schema(colander.Schema):
+            pepper = colander.SchemaNode(
+                colander.Set(),
+                widget=deform.widget.Select2Widget(
+                    values=choices, multiple=True, tags=True
+                ),
+            )
+
+        schema = Schema()
+        form = deform.Form(schema, buttons=("submit",))
+
+        return self.render_form(form)
+
     @view_config(renderer="templates/form.pt", name="checkboxchoice")
     @demonstrate("Checkbox Choice Widget")
     def checkboxchoice(self):

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -2524,6 +2524,65 @@ class Select2WidgetWithOptgroupTests(Base, unittest.TestCase):
         )
 
 
+class Select2TagsWidgetTests(Base, unittest.TestCase):
+    url = test_url("/select2_with_tags/")
+
+    def test_submit_new_option(self):
+        # open select search field
+        findcss(".select2-container").click()
+
+        # options list is empty
+        self.assertSimilarRepr(
+            findid("select2-deformField1-results").text, "No results found"
+        )
+
+        # type a value in selec2 search
+        (
+            findid("public")
+            .find_element_by_css_selector(".select2-search__field")
+            .send_keys("hello\n")
+        )
+
+        # after form submission typed value appear in captured
+        findid("deformsubmit").click()
+        captured = findid("captured").text
+        self.assertSimilarRepr(
+            captured, "{'pepper': 'hello'}",
+        )
+
+
+class Select2WidgetTagsMultipleTests(Base, unittest.TestCase):
+    url = test_url("/select2_with_tags_and_multiple/")
+
+    def test_submit_new_options(self):
+        # multiple submission is activated
+        self.assertTrue(findid("deformField1").get_attribute("multiple"))
+
+        # options list is empty
+        findid("item-deformField1").click()
+        self.assertSimilarRepr(
+            findid("select2-deformField1-results").text, "No results found"
+        )
+
+        # adding values to select field
+        for value in ("hello", "qwerty", "hello"):
+            # open select search field
+            findid("item-deformField1").click()
+            # type values in selec2 search
+            (
+                findid("public")
+                .find_element_by_css_selector(".select2-search__field")
+                .send_keys(value + "\n")
+            )
+
+        # after form submission typed value appear in captured
+        findid("deformsubmit").click()
+        captured = findid("captured").text
+        self.assertSimilarRepr(
+            captured, "{'pepper': {'hello', 'qwerty'} }",
+        )
+
+
 class SelectWithDefaultTests(Base, unittest.TestCase):
 
     url = test_url("/select_with_default/")


### PR DESCRIPTION
**Original issue**: Pylons/deform#372
**Depends on**: https://github.com/Pylons/deform/pull/373.

**Tags multiple example**:
![multytag](https://user-images.githubusercontent.com/963412/40889269-627fcdce-676c-11e8-9ec9-2a901f77eaf2.gif)

**Tags example**:
![tag](https://user-images.githubusercontent.com/963412/40889267-5b6e206c-676c-11e8-9715-ae78864aa82f.gif)
