### PR TITLE
Make link consistent with code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Run the latest version of this application with Docker.
     docker run -d -p 8000:8522 pylons/deformdemo:v2.0.7
 
 
-Then, in your browser, visit http://localhost:8080
+Then, in your browser, visit http://localhost:8000
 
 
 From source


### PR DESCRIPTION
The link to `localhost:8080` is not consistent with the port mapping in the docker run command.