### PR TITLE
Bump up the thread count from the default 4 to 8 threads.

### DIFF
--- a/demo.ini
+++ b/demo.ini
@@ -15,6 +15,7 @@ pyramid.default_locale_name = en
 use = egg:waitress#main
 host = 0.0.0.0
 port = 8522
+threads = 8
 
 [loggers]
 keys = root, deformdemo


### PR DESCRIPTION
This should remove noise of Waitress's "Task queue depth is 1" warnings in the test output on Travis.