### PR TITLE
Added sort_dicts argument to my_safe_repr

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,4 @@ Contributors
 - Martin Peeters 2016/10/22
 - Érico Andrei 2018/11/10
 - Steve Piercy 2020/05/11
+- John Haiducek 2020/06/20

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -78,6 +78,9 @@ def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
     if type(obj) == unicode:
         obj = obj.encode("utf-8")
 
+    # Python 3.8 changed the call signature of pprint._safe_repr.
+    # In order to support both Python 3.8 and earlier versions
+    # we have to check its signature before calling
     sig = signature(pprint._safe_repr)
     if len(sig.parameters) == 5:
         return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -71,10 +71,10 @@ class demonstrate(object):
 # Py2/Py3 compat
 # http://stackoverflow.com/a/16888673/315168
 # eliminate u''
-def my_safe_repr(obj, context, maxlevels, level):
+def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
     if type(obj) == unicode:
         obj = obj.encode("utf-8")
-    return pprint._safe_repr(obj, context, maxlevels, level)
+    return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)
 
 
 @view_defaults(route_name="deformdemo")

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -72,9 +72,12 @@ class demonstrate(object):
 # http://stackoverflow.com/a/16888673/315168
 # eliminate u''
 def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
+
+    from inspect import signature
+
     if type(obj) == unicode:
         obj = obj.encode("utf-8")
-    from inspect import signature
+
     sig = signature(pprint._safe_repr)
     if len(sig.parameters) == 5:
         return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -74,7 +74,12 @@ class demonstrate(object):
 def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
     if type(obj) == unicode:
         obj = obj.encode("utf-8")
-    return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)
+    from inspect import signature
+    sig=signature(pprint._safe_repr)
+    if(len(sig.parameters)==5):
+        return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)
+    else:
+        return pprint._safe_repr(obj, context, maxlevels, level)
 
 
 @view_defaults(route_name="deformdemo")

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -75,8 +75,8 @@ def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
     if type(obj) == unicode:
         obj = obj.encode("utf-8")
     from inspect import signature
-    sig=signature(pprint._safe_repr)
-    if(len(sig.parameters)==5):
+    sig = signature(pprint._safe_repr)
+    if len(sig.parameters) == 5:
         return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)
     else:
         return pprint._safe_repr(obj, context, maxlevels, level)


### PR DESCRIPTION
This PR makes deformdemo work with newer versions of Python. sort_dicts is a required argument of pprint._safe_repr in newer versions of Python.