### PR TITLE
Change dateparts widget to use type=number

### DIFF
--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -1245,9 +1245,9 @@ class MappingWidgetTests(Base, unittest.TestCase):
     def test_submit_invalid_date(self):
         findid("deformField1").send_keys("1")
         findid("deformField3").send_keys("name")
-        findid("deformField4").send_keys("year")
-        findid("deformField4-month").send_keys("month")
-        findid("deformField4-day").send_keys("day")
+        findid("deformField4").send_keys("2020")
+        findid("deformField4-month").send_keys("2")
+        findid("deformField4-day").send_keys("31")
         wait_to_click("#deformsubmit")
         self.assertTrue(findcss(".is-invalid"))
         self.assertEqual(findid("error-deformField4").text, "Invalid date")
@@ -1255,14 +1255,15 @@ class MappingWidgetTests(Base, unittest.TestCase):
             findid_view("deformField1").get_attribute("value"), "1"
         )
         self.assertEqual(findid("deformField3").get_attribute("value"), "name")
-        self.assertEqual(findid("deformField4").get_attribute("value"), "year")
+        self.assertEqual(findid("deformField4").get_attribute("value"), "2020")
         self.assertEqual(
-            findid("deformField4-month").get_attribute("value"), "mo"
+            findid("deformField4-month").get_attribute("value"), "2"
         )
         self.assertEqual(
-            findid("deformField4-day").get_attribute("value"), "da"
+            findid("deformField4-day").get_attribute("value"), "31"
         )
         self.assertEqual(findid("captured").text, "None")
+        time.sleep(10)
 
     def test_submit_success(self):
         findid("deformField1").send_keys("1")


### PR DESCRIPTION
- Adjust test to submit only numbers, but still be an invalid date (2020-02-31)
- Fixes #442