### PR TITLE
Add unofficial deformdemo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,11 @@
 2.0.15 (unreleased)
 -------------------
 
+- Added unofficial deformdemo. This provides a space for contributors to add
+  their widgets without requiring tests, especially when the functional tests
+  cannot pass using Selenium. [sydoluciani]
+  https://github.com/Pylons/deformdemo/pull/92
+
 - Changed dateparts widget to use ``type="number"`` instead of default `text`.
   https://github.com/Pylons/deform/issues/442
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 graft deformdemo
+graft unofficial-deformdemo
 
 include *.py
 include *.sh

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2901,4 +2901,7 @@ def main(global_config, **settings):
         pass
 
     config.scan("deformdemo", onerror=onerror)
+
+    config.include('..unofficial-deformdemo')
+
     return config.make_wsgi_app()

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2897,10 +2897,10 @@ def main(global_config, **settings):
         translator,
     )
     config.add_static_view("static_deform", "deform:static")
-    config.add_route("deformdemo", "*traverse")
     config.add_route(
         "unofficial-deformdemo", "/unofficial-deformdemo*traverse"
     )
+    config.add_route("deformdemo", "*traverse")
 
     def onerror(*arg):
         pass

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2896,7 +2896,6 @@ def main(global_config, **settings):
         ("deformdemo:custom_widgets", "unofficial-deformdemo:custom_widgets"),
         translator,
     )
-
     config.add_static_view("static_deform", "deform:static")
     config.add_route("deformdemo", "*traverse")
     config.add_route(
@@ -2907,7 +2906,5 @@ def main(global_config, **settings):
         pass
 
     config.scan("deformdemo", onerror=onerror)
-
     config.include('..unofficial-deformdemo')
-
     return config.make_wsgi_app()

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2892,7 +2892,10 @@ def main(global_config, **settings):
         return get_localizer(get_current_request()).translate(term)
 
     # Configure renderer
-    configure_zpt_renderer(("deformdemo:custom_widgets",), translator)
+    configure_zpt_renderer(
+        ("deformdemo:custom_widgets", "unofficial-deformdemo:custom_widgets"),
+        translator,
+    )
 
     config.add_static_view("static_deform", "deform:static")
     config.add_route("deformdemo", "*traverse")

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2898,6 +2898,11 @@ def main(global_config, **settings):
     )
 
     config.add_static_view("static_deform", "deform:static")
+
+    config.add_route(
+        "unofficial-deformdemo", "/unofficial-deformdemo*traverse"
+    )
+
     config.add_route("deformdemo", "*traverse")
 
     def onerror(*arg):

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2898,12 +2898,10 @@ def main(global_config, **settings):
     )
 
     config.add_static_view("static_deform", "deform:static")
-
+    config.add_route("deformdemo", "*traverse")
     config.add_route(
         "unofficial-deformdemo", "/unofficial-deformdemo*traverse"
     )
-
-    config.add_route("deformdemo", "*traverse")
 
     def onerror(*arg):
         pass

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -2906,5 +2906,5 @@ def main(global_config, **settings):
         pass
 
     config.scan("deformdemo", onerror=onerror)
-    config.include('..unofficial-deformdemo')
+    config.include("..unofficial-deformdemo")
     return config.make_wsgi_app()

--- a/deformdemo/templates/index.pt
+++ b/deformdemo/templates/index.pt
@@ -3,17 +3,20 @@
   <div metal:fill-slot="main" tal:omit-tag="">
     <div class="page-header">
       <h1><a href="https://docs.pylonsproject.org/projects/deform/en/latest/">Deform</a> is a Python library for generating HTML
-        forms<br/><small>Each link on the left demonstrates a capability</small>
+        forms.<br/>
+        <small>Each link on the left demonstrates a capability.</small>
       </h1>
     </div>
 
     <div class="well">
 
+      <p>The <a href="/">official Deform Demo</a> supports tested and documented widgets.
+        The <a href="/unofficial-deformdemo">unofficial Deform Demo</a> provides a space for contributors to add custom widgets that are not supported with the usual rigorous tests and documentation that is required by the Pylons Project.</p>
       <p>
         This demo is written using <a
         href="https://trypyramid.com/">Pyramid</a>. Note that Deform does
-        not depend on any particular web framework,
-        we just had to write a demo application in <em>something</em>.
+        not depend on any particular web framework.
+        We had to write a demo application in <em>something</em>.
         If you would like to run this demo application locally,
         please read the <a href="https://github.com/Pylons/deformdemo">README
         file for installation of this application</a>.

--- a/deformdemo/templates/main.pt
+++ b/deformdemo/templates/main.pt
@@ -60,9 +60,14 @@
 
     <div class="navbar navbar-default" role="navigation">
         <div class="container">
-            <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span>
-                                             <span i18n:translate=""> Deform Demo</span>
-            </a>
+          <ul class="nav nav-pills">
+            <li class="nav-item active">
+              <a class="nav-link active" href="/"><span i18n:translate="">Deform Demo</span></a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/unofficial-deformdemo"><span i18n:translate="">Unofficial Deform Demo</span></a>
+            </li>
+          </ul>
         </div>
     </div>
 

--- a/unofficial-deformdemo/__init__.py
+++ b/unofficial-deformdemo/__init__.py
@@ -1,0 +1,2 @@
+def includeme(config):
+    pass

--- a/unofficial-deformdemo/__init__.py
+++ b/unofficial-deformdemo/__init__.py
@@ -1,2 +1,232 @@
+# -*- coding: utf-8 -*-
+
+""" A Pyramid app that demonstrates various Deform widgets and
+capabilities and which provides a functional test suite  """
+
+import inspect
+import logging
+import pprint
+import sys
+
+import colander
+from pyramid.i18n import TranslationStringFactory
+from pyramid.i18n import get_locale_name
+from pyramid.renderers import get_renderer
+from pyramid.response import Response
+from pyramid.view import view_config
+from pyramid.view import view_defaults
+
+import deform
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import PythonLexer
+
+
+log = logging.getLogger(__name__)
+
+
+PY3 = sys.version_info[0] == 3
+PY38MIN = sys.version_info[0] == 3 and sys.version_info[1] >= 8
+
+if PY3:
+
+    def unicode(val, encoding="utf-8"):
+        return val
+
+
+_ = TranslationStringFactory("deformdemo")
+
+formatter = HtmlFormatter(nowrap=True)
+css = formatter.get_style_defs()
+
+# the zpt_renderer above is referred to within the demo.ini file by dotted name
+
+
+class demonstrate(object):
+    def __init__(self, title):
+        self.title = title
+
+    def __call__(self, method):
+        method.demo = self.title
+        return method
+
+
+# Py2/Py3 compat
+# http://stackoverflow.com/a/16888673/315168
+# eliminate u''
+def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
+
+    if type(obj) == unicode:
+        obj = obj.encode("utf-8")
+
+    # Python 3.8 changed the call signature of pprint._safe_repr.
+    # by adding sort_dicts.
+    if PY38MIN:
+        return pprint._safe_repr(obj, context, maxlevels, level, sort_dicts)
+    else:
+        return pprint._safe_repr(obj, context, maxlevels, level)
+
+
+@view_defaults(route_name="deformdemo")
+class DeformDemo(object):
+    def __init__(self, request):
+        self.request = request
+        self.macros = get_renderer("templates/main.pt").implementation().macros
+
+    def render_form(
+        self,
+        form,
+        appstruct=colander.null,
+        submitted="submit",
+        success=None,
+        readonly=False,
+        is_i18n=False,
+    ):
+
+        captured = None
+
+        if submitted in self.request.POST:
+            # the request represents a form submission
+            try:
+                # try to validate the submitted values
+                controls = self.request.POST.items()
+                captured = form.validate(controls)
+                if success:
+                    response = success()
+                    if response is not None:
+                        return response
+                html = form.render(captured)
+            except deform.ValidationFailure as e:
+                # the submitted values could not be validated
+                html = e.render()
+
+        else:
+            # the request requires a simple form rendering
+            html = form.render(appstruct, readonly=readonly)
+
+        if self.request.is_xhr:
+            return Response(html)
+
+        code, start, end = self.get_code(2)
+        locale_name = get_locale_name(self.request)
+
+        reqts = form.get_widget_resources()
+
+        printer = pprint.PrettyPrinter()
+        printer.format = my_safe_repr
+        output = printer.pformat(captured)
+        captured = highlight(output, PythonLexer(), formatter)
+
+        # values passed to template for rendering
+        return {
+            "form": html,
+            "captured": captured,
+            "code": code,
+            "start": start,
+            "end": end,
+            "is_i18n": is_i18n,
+            "locale": locale_name,
+            "demos": self.get_demos(),
+            "title": self.get_title(),
+            "css_links": reqts["css"],
+            "js_links": reqts["js"],
+        }
+
+    def get_code(self, level):
+        frame = sys._getframe(level)
+        lines, start = inspect.getsourcelines(frame.f_code)
+        end = start + len(lines)
+        code = "".join(lines)
+        if not PY3:
+            code = unicode(code, "utf-8")
+        return highlight(code, PythonLexer(), formatter), start, end
+
+    @view_config(name="thanks.html")
+    def thanks(self):
+        return Response(
+            "<html><body><p>Thanks!</p><small>"
+            '<a href="..">Up</a></small></body></html>'
+        )
+
+    @view_config(name="allcode", renderer="templates/code.pt")
+    def allcode(self):
+        params = self.request.params
+        start = params.get("start")
+        end = params.get("end")
+        hl_lines = None
+        if start and end:
+            start = int(start)
+            end = int(end)
+            hl_lines = list(range(start, end))
+        code = open(inspect.getsourcefile(self.__class__), "r").read()
+        code = code.encode("utf-8")
+        formatter = HtmlFormatter(
+            linenos="table",
+            lineanchors="line",
+            cssclass="hightlight ",
+            hl_lines=hl_lines,
+        )
+        html = highlight(code, PythonLexer(), formatter)
+        return {"code": html, "demos": self.get_demos()}
+
+    def get_title(self):
+        # gross hack; avert your eyes
+        frame = sys._getframe(3)
+        attr = frame.f_locals["attr"]
+        inst = frame.f_locals["inst"]
+        method = getattr(inst, attr)
+        return method.demo
+
+    @view_config(name="pygments.css")
+    def cssview(self):
+        response = Response(body=css, content_type="text/css")
+        response.cache_expires = 360
+        return response
+
+    @view_config(renderer="templates/index.pt")
+    def index(self):
+        return {"demos": self.get_demos()}
+
+    def get_demos(self):
+        def predicate(value):
+            if getattr(value, "demo", None) is not None:
+                return True
+
+        demos = inspect.getmembers(self, predicate)
+        L = []
+        for name, method in demos:
+            url = self.request.resource_url(
+                self.request.root, name, route_name="deformdemo"
+            )
+            L.append((method.demo, url))
+        L.sort()
+        return L
+
+    @view_config(renderer="templates/form.pt", name="textinput")
+    @demonstrate("Text Input Widget")
+    def textinput(self):
+        class Schema(colander.Schema):
+            text = colander.SchemaNode(
+                colander.String(),
+                validator=colander.Length(max=100),
+                widget=deform.widget.TextInputWidget(),
+                description="Enter some text",
+            )
+
+        schema = Schema()
+        form = deform.Form(schema, buttons=("submit",))
+
+        return self.render_form(form)
+
+
 def includeme(config):
-    pass
+
+    # Configure renderer
+    config.add_static_view(
+        "static_unofficial-deformdemo", "unofficial-deformdemo:static"
+    )
+    config.add_route(
+        "unofficial-deformdemo", "/unofficial-deformdemo*traverse"
+    )
+
+    config.scan("unofficial-deformdemo")

--- a/unofficial-deformdemo/__init__.py
+++ b/unofficial-deformdemo/__init__.py
@@ -67,8 +67,8 @@ def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
         return pprint._safe_repr(obj, context, maxlevels, level)
 
 
-@view_defaults(route_name='unofficial-deformdemo')
-class UnOfficialDeformDemo(object):
+@view_defaults(route_name="unofficial-deformdemo")
+class UnofficialDeformDemo(object):
     def __init__(self, request):
         self.request = request
         self.macros = get_renderer("templates/main.pt").implementation().macros
@@ -141,7 +141,7 @@ class UnOfficialDeformDemo(object):
             code = unicode(code, "utf-8")
         return highlight(code, PythonLexer(), formatter), start, end
 
-    @view_config(name="thanks.html", route_name='unofficial-deformdemo')
+    @view_config(name="thanks.html", route_name="unofficial-deformdemo")
     def thanks(self):
         return Response(
             "<html><body><p>Thanks!</p><small>"
@@ -150,7 +150,7 @@ class UnOfficialDeformDemo(object):
 
     @view_config(name="allcode",
                  renderer="templates/code.pt",
-                 route_name='unofficial-deformdemo')
+                 route_name="unofficial-deformdemo")
     def allcode(self):
         params = self.request.params
         start = params.get("start")
@@ -179,14 +179,14 @@ class UnOfficialDeformDemo(object):
         method = getattr(inst, attr)
         return method.demo
 
-    @view_config(name="pygments.css", route_name='unofficial-deformdemo')
+    @view_config(name="pygments.css", route_name="unofficial-deformdemo")
     def cssview(self):
         response = Response(body=css, content_type="text/css")
         response.cache_expires = 360
         return response
 
     @view_config(renderer="templates/index.pt",
-                 route_name='unofficial-deformdemo')
+                 route_name="unofficial-deformdemo")
     def index(self):
         return {"demos": self.get_demos()}
 
@@ -205,11 +205,11 @@ class UnOfficialDeformDemo(object):
         L.sort()
         return L
 
-    # Unofficial Deform Demo Forms Starts Here.
+    # Unofficial Deform Demo Forms Start Here.
 
     @view_config(name="textinput",
                  renderer="templates/form.pt",
-                 route_name='unofficial-deformdemo')
+                 route_name="unofficial-deformdemo")
     @demonstrate("Text Input Widget")
     def textinput(self):
         class Schema(colander.Schema):

--- a/unofficial-deformdemo/__init__.py
+++ b/unofficial-deformdemo/__init__.py
@@ -34,7 +34,7 @@ if PY3:
         return val
 
 
-_ = TranslationStringFactory("deformdemo")
+_ = TranslationStringFactory("unofficial-deformdemo")
 
 formatter = HtmlFormatter(nowrap=True)
 css = formatter.get_style_defs()
@@ -67,8 +67,8 @@ def my_safe_repr(obj, context, maxlevels, level, sort_dicts=True):
         return pprint._safe_repr(obj, context, maxlevels, level)
 
 
-@view_defaults(route_name="deformdemo")
-class DeformDemo(object):
+@view_defaults(route_name='unofficial-deformdemo')
+class UnOfficialDeformDemo(object):
     def __init__(self, request):
         self.request = request
         self.macros = get_renderer("templates/main.pt").implementation().macros
@@ -141,14 +141,16 @@ class DeformDemo(object):
             code = unicode(code, "utf-8")
         return highlight(code, PythonLexer(), formatter), start, end
 
-    @view_config(name="thanks.html")
+    @view_config(name="thanks.html", route_name='unofficial-deformdemo')
     def thanks(self):
         return Response(
             "<html><body><p>Thanks!</p><small>"
             '<a href="..">Up</a></small></body></html>'
         )
 
-    @view_config(name="allcode", renderer="templates/code.pt")
+    @view_config(name="allcode",
+                 renderer="templates/code.pt",
+                 route_name='unofficial-deformdemo')
     def allcode(self):
         params = self.request.params
         start = params.get("start")
@@ -177,13 +179,14 @@ class DeformDemo(object):
         method = getattr(inst, attr)
         return method.demo
 
-    @view_config(name="pygments.css")
+    @view_config(name="pygments.css", route_name='unofficial-deformdemo')
     def cssview(self):
         response = Response(body=css, content_type="text/css")
         response.cache_expires = 360
         return response
 
-    @view_config(renderer="templates/index.pt")
+    @view_config(renderer="templates/index.pt",
+                 route_name='unofficial-deformdemo')
     def index(self):
         return {"demos": self.get_demos()}
 
@@ -196,13 +199,17 @@ class DeformDemo(object):
         L = []
         for name, method in demos:
             url = self.request.resource_url(
-                self.request.root, name, route_name="deformdemo"
+                self.request.root, name, route_name="unofficial-deformdemo"
             )
             L.append((method.demo, url))
         L.sort()
         return L
 
-    @view_config(renderer="templates/form.pt", name="textinput")
+    # Unofficial Deform Demo Forms Starts Here.
+
+    @view_config(name="textinput",
+                 renderer="templates/form.pt",
+                 route_name='unofficial-deformdemo')
     @demonstrate("Text Input Widget")
     def textinput(self):
         class Schema(colander.Schema):
@@ -220,13 +227,5 @@ class DeformDemo(object):
 
 
 def includeme(config):
-
-    # Configure renderer
-    config.add_static_view(
-        "static_unofficial-deformdemo", "unofficial-deformdemo:static"
-    )
-    config.add_route(
-        "unofficial-deformdemo", "/unofficial-deformdemo*traverse"
-    )
 
     config.scan("unofficial-deformdemo")

--- a/unofficial-deformdemo/templates/code.pt
+++ b/unofficial-deformdemo/templates/code.pt
@@ -1,0 +1,6 @@
+<div metal:use-macro="view.macros['master']">
+  <div metal:fill-slot="main">
+    <h2>Module Code</h2>
+    <span tal:replace="structure code"/>
+  </div>
+</div>

--- a/unofficial-deformdemo/templates/form.pt
+++ b/unofficial-deformdemo/templates/form.pt
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<div metal:use-macro="view.macros['master']"
+     i18n:domain="deformdemo">
+  <div metal:fill-slot="main">
+    <div class="btn-group" tal:condition="is_i18n|False">
+        <a tal:attributes="class locale == 'en' and 'active btn btn-default' or 'btn btn-default'" href="${request.path_url}?_LOCALE_=en">English</a>
+        <a tal:attributes="class locale == 'de' and 'active btn btn-default' or 'btn btn-default'" href="${request.path_url}?_LOCALE_=de">Deutsch</a>
+        <a tal:attributes="class locale == 'nl' and 'active btn btn-default' or 'btn btn-default'" href="${request.path_url}?_LOCALE_=nl">Nederlands</a>
+        <a tal:attributes="class locale == 'ru' and 'active btn btn-default' or 'btn btn-default'" href="${request.path_url}?_LOCALE_=ru">Russian</a>
+        <a tal:attributes="class locale == 'es' and 'active btn btn-default' or 'btn btn-default'" href="${request.path_url}?_LOCALE_=es">Español</a>
+        <br />
+        <br />
+    </div>
+
+
+    <div class="panel panel-primary">
+      <div class="panel-heading">
+        <h3 class="panel-title">Demo: ${title}</h3>
+      </div>
+      <div class="panel-body">
+        <div id="form" tal:content="structure form"/>
+      </div>
+    </div>
+
+    <div class="panel panel-info">
+      <div class="panel-heading">
+        <h3 class="panel-title">Captured submission</h3>
+      </div>
+      <div class="panel-body">
+        <pre style="border: none; background-color: #FFF" class="highlight" id="captured" tal:content="structure captured"/>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Code <a href="${request.resource_url(request.root, 'allcode', query={'start':start, 'end':end}, anchor='line-%s' % start)}"><small>
+        (click to show in context)</small></a>
+        </h3>
+      </div>
+      <div class="panel-body highlight">
+        <pre style="border: none; background-color: #FFF" tal:content="structure code"/>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/unofficial-deformdemo/templates/index.pt
+++ b/unofficial-deformdemo/templates/index.pt
@@ -3,17 +3,20 @@
   <div metal:fill-slot="main" tal:omit-tag="">
     <div class="page-header">
       <h1><a href="https://docs.pylonsproject.org/projects/deform/en/latest/">Deform</a> is a Python library for generating HTML
-        forms<br/><small>Each link on the left demonstrates a capability</small>
+        forms.<br/>
+        <small>Each link on the left demonstrates a capability.</small>
       </h1>
     </div>
 
     <div class="well">
 
+      <p>The <a href="/">official Deform Demo</a> supports tested and documented widgets.
+        The <a href="/unofficial-deformdemo">unofficial Deform Demo</a> provides a space for contributors to add custom widgets that are not supported with the usual rigorous tests and documentation that is required by the Pylons Project.</p>
       <p>
         This demo is written using <a
         href="https://trypyramid.com/">Pyramid</a>. Note that Deform does
-        not depend on any particular web framework,
-        we just had to write a demo application in <em>something</em>.
+        not depend on any particular web framework.
+        We had to write a demo application in <em>something</em>.
         If you would like to run this demo application locally,
         please read the <a href="https://github.com/Pylons/deformdemo">README
         file for installation of this application</a>.

--- a/unofficial-deformdemo/templates/index.pt
+++ b/unofficial-deformdemo/templates/index.pt
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<div metal:use-macro="view.macros['master']">
+  <div metal:fill-slot="main" tal:omit-tag="">
+    <div class="page-header">
+      <h1><a href="https://docs.pylonsproject.org/projects/deform/en/latest/">Deform</a> is a Python library for generating HTML
+        forms<br/><small>Each link on the left demonstrates a capability</small>
+      </h1>
+    </div>
+
+    <div class="well">
+
+      <p>
+        This demo is written using <a
+        href="https://trypyramid.com/">Pyramid</a>. Note that Deform does
+        not depend on any particular web framework,
+        we just had to write a demo application in <em>something</em>.
+        If you would like to run this demo application locally,
+        please read the <a href="https://github.com/Pylons/deformdemo">README
+        file for installation of this application</a>.
+      </p>
+
+      <p>
+        For further information, see
+        the <a href="https://docs.pylonsproject.org/projects/deform/en/latest/">Deform documentation</a>.
+      </p>
+
+    </div>
+
+  </div>
+</div>
+

--- a/unofficial-deformdemo/templates/main.pt
+++ b/unofficial-deformdemo/templates/main.pt
@@ -10,11 +10,11 @@
         <meta name="viewport"
               content="width=device-width, initial-scale=1.0">
         <title i18n:translate="">
-            Deform Demo Site
+            Unofficial Deform Demo Site
         </title>
 
         <link rel="stylesheet"
-              href="${request.resource_url(request.root, 'pygments.css', route_name='deformdemo')}"
+              href="${request.resource_url(request.root, 'pygments.css', route_name='unofficial-deformdemo')}"
               type="text/css"/>
 
         <link rel="stylesheet"
@@ -61,7 +61,7 @@
     <div class="navbar navbar-default" role="navigation">
         <div class="container">
             <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span>
-                                             <span i18n:translate=""> Deform Demo</span>
+                                             <span i18n:translate=""> Unofficial Deform Demo</span>
             </a>
         </div>
     </div>

--- a/unofficial-deformdemo/templates/main.pt
+++ b/unofficial-deformdemo/templates/main.pt
@@ -1,0 +1,93 @@
+<metal:block define-macro="master">
+  <!DOCTYPE html>
+    <html tal:define="app_url request.application_url;
+                      static request.static_url('deform:static/')"
+          xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="deformdemo">
+
+    <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1.0">
+        <title i18n:translate="">
+            Deform Demo Site
+        </title>
+
+        <link rel="stylesheet"
+              href="${request.resource_url(request.root, 'pygments.css', route_name='deformdemo')}"
+              type="text/css"/>
+
+        <link rel="stylesheet"
+              href="${request.static_url('deform:static/css/form.css')}"
+              type="text/css"/>
+
+        <style type="text/css">
+           .linenodiv pre {
+             word-break: normal;
+           }
+        </style>
+
+        <!-- CSS -->
+        <link rel="stylesheet"
+              href="${request.static_url('deform:static/css/bootstrap.min.css')}"
+              type="text/css" media="screen" charset="utf-8"/>
+        <link rel="stylesheet"
+              href="${request.static_url('deform:static/css/form.css')}"
+              type="text/css"/>
+        <tal:block repeat="reqt css_links|[]">
+            <link rel="stylesheet" href="${request.static_url(reqt)}" type="text/css" />
+        </tal:block>
+
+        <!-- JavaScript -->
+        <script src="${request.static_url('deform:static/scripts/jquery-2.0.3.min.js')}"
+                type="text/javascript"></script>
+        <script src="${request.static_url('deform:static/scripts/bootstrap.min.js')}"
+                type="text/javascript"></script>
+        <tal:block repeat="reqt js_links|[]">
+            <script type="text/javascript" src="${request.static_url(reqt)}"></script>
+        </tal:block>
+
+        <script>
+            // This forces us to use JS date time picker polyfill so that our functional tests can run properly regardless of a browser
+            window.forceDateTimePolyfill = true;
+        </script>
+
+        <tal:slot metal:define-slot="head_end"></tal:slot>
+
+    </head>
+
+    <body id="public">
+
+    <div class="navbar navbar-default" role="navigation">
+        <div class="container">
+            <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span>
+                                             <span i18n:translate=""> Deform Demo</span>
+            </a>
+        </div>
+    </div>
+
+    <div class="container">
+
+        <div class="row" style="margin-top: 10px">
+            <div class="col-3 col-lg-3 col-sm-3">
+                <div class="list-group">
+                    <a href="${name}/"
+                       tal:attributes="class python: name + '/' in request.url and 'list-group-item active' or 'list-group-item'"
+                       tal:repeat="(title, name) demos">
+                        ${title}
+                    </a>
+                </div>
+            </div>
+            <div class="col-9 col-lg-9 col-sm-9">
+                <span metal:define-slot="main"/>
+            </div>
+        </div>
+
+    </div>
+
+
+    <tal:slot metal:define-slot="body_end"></tal:slot>
+    </body>
+
+    </html>
+</metal:block>

--- a/unofficial-deformdemo/templates/main.pt
+++ b/unofficial-deformdemo/templates/main.pt
@@ -60,9 +60,14 @@
 
     <div class="navbar navbar-default" role="navigation">
         <div class="container">
-            <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-info-sign"></span>
-                                             <span i18n:translate=""> Unofficial Deform Demo</span>
-            </a>
+          <ul class="nav nav-pills">
+            <li class="nav-item">
+              <a class="nav-link" href="/"><span i18n:translate="">Deform Demo</span></a>
+            </li>
+            <li class="nav-item active">
+              <a class="nav-link active" href="/unofficial-deformdemo"><span i18n:translate="">Unofficial Deform Demo</span></a>
+            </li>
+          </ul>
         </div>
     </div>
 

--- a/unofficial-deformdemo/templates/mini.pt
+++ b/unofficial-deformdemo/templates/mini.pt
@@ -1,0 +1,66 @@
+<metal:block define-macro="master">
+  <!DOCTYPE html>
+  <html tal:define="app_url request.application_url; static request.static_url('deform:static/')">
+
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0">
+    <title>
+      Deform mini demo
+    </title>
+
+    <link rel="stylesheet"
+          href="${request.static_url('deform:static/css/form.css')}"
+          type="text/css"/>
+
+    <!-- CSS -->
+    <link rel="stylesheet"
+          href="${request.static_url('deform:static/css/bootstrap.min.css')}"
+          type="text/css" media="screen" charset="utf-8"/>
+    <link rel="stylesheet"
+          href="${request.static_url('deform:static/css/form.css')}"
+          type="text/css"/>
+    <tal:block repeat="reqt css_links|[]">
+      <link rel="stylesheet" href="${request.static_url(reqt)}" type="text/css"/>
+    </tal:block>
+
+    <!-- JavaScript -->
+    <script src="${request.static_url('deform:static/scripts/jquery-2.0.3.min.js')}"
+            type="text/javascript"></script>
+    <script src="${request.static_url('deform:static/scripts/bootstrap.min.js')}"
+            type="text/javascript"></script>
+    <tal:block repeat="reqt js_links|[]">
+      <script type="text/javascript" src="${request.static_url(reqt)}"></script>
+    </tal:block>
+  </head>
+
+  <body id="public">
+
+    <!-- Render Pyramid flash message queue -->
+    <div id="flash-messages" tal:condition="request.session.peek_flash()">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="alert alert-info" tal:repeat="message request.session.pop_flash()">
+              ${message}<br>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1>Deform mini example</h1>
+
+          <div tal:replace="structure rendered_form"></div>
+        </div>
+      </div>
+    </div>
+
+  </body>
+
+  </html>
+</metal:block>

--- a/unofficial-deformdemo/templates/popup_example.pt
+++ b/unofficial-deformdemo/templates/popup_example.pt
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<div metal:use-macro="view.macros['master']">
+
+  <div metal:fill-slot="head_end">
+    <style>
+      #opener {
+        margin: 20px;
+      }
+    </style>
+  </div>
+
+  <div metal:fill-slot="body_end">
+    <!-- We we place our pop up code before closing </body> -->
+    <script>
+      "use strict";
+
+      $(document).ready(function() {
+        // Automatically show pop up if the form contains validation errors
+        if($("#my-pop-up .error-msg-detail").length > 0) {
+          $("#my-pop-up").modal("show");
+        }
+      });
+    </script>
+  </div>
+
+  <div metal:fill-slot="main">
+
+    <div class="panel panel-primary">
+      <div class="panel-heading">
+        <h3 class="panel-title">Demo: ${title}</h3>
+      </div>
+
+      <div id="opener">
+        <button type="button" id="btn-show-pop-up" class="btn btn-primary btn-lg btn-block" data-toggle="modal" data-target="#my-pop-up">
+          Open pop up form
+        </button>
+        </div>
+
+      <!-- Variable `form` contains the renderer form HTML as a Python string -->
+      <form tal:replace="structure form"></form>
+
+    </div>
+
+    <div class="panel panel-info">
+      <div class="panel-heading">
+        <h3 class="panel-title">Captured submission</h3>
+      </div>
+      <div class="panel-body">
+        <pre style="border: none; background-color: #FFF" class="highlight" id="captured" tal:content="structure captured"/>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Code <a href="${request.resource_url(request.root, 'allcode', query={'start':start, 'end':end}, anchor='line-%s' % start)}"><small>
+        (click to show in context)</small></a>
+        </h3>
+      </div>
+      <div class="panel-body highlight">
+        <pre style="border: none; background-color: #FFF" tal:content="structure code"/>
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
Adding Unofficial Deform Demo to facilitate submitting of new forms and custom widgets with no test.

Official Deform Demo still can be accessed through:
http://domain_name:8522

Unofficial Deform Demo can be accessed:
http://domain_name:8522/unofficial-deformdemo